### PR TITLE
Add comprehensive documentation, Copilot agents, skills, hooks, and MCP config

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "husky": {
+      "version": "0.7.2",
+      "commands": [
+        "husky"
+      ]
+    }
+  }
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,213 @@
+# Top-most EditorConfig file
+root = true
+
+###############################################################################
+# Default settings (all files)
+###############################################################################
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = crlf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+###############################################################################
+# C# files
+###############################################################################
+[*.cs]
+indent_size = 4
+
+# --- Using directives -----------------------------------------------------------
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+# --- Namespace style (block-scoped for .NET Framework) -----------------------
+csharp_style_namespace_declarations = block_scoped:warning
+
+# --- var preferences ---------------------------------------------------------
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = false:suggestion
+
+# --- Expression-bodied members -----------------------------------------------
+csharp_style_expression_bodied_methods = false:suggestion
+csharp_style_expression_bodied_constructors = false:suggestion
+csharp_style_expression_bodied_operators = false:suggestion
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_expression_bodied_accessors = true:suggestion
+
+# --- Null checking -----------------------------------------------------------
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+
+# --- Code style preferences --------------------------------------------------
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+dotnet_style_readonly_field = true:suggestion
+csharp_prefer_braces = true:suggestion
+csharp_prefer_simple_using_statement = false:none
+
+# --- 'this.' qualification ---------------------------------------------------
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+###############################################################################
+# New-line settings (Allman / BSD style)
+###############################################################################
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+###############################################################################
+# Indentation settings
+###############################################################################
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+
+###############################################################################
+# Spacing settings
+###############################################################################
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+
+###############################################################################
+# Wrapping settings
+###############################################################################
+csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_blocks = true
+
+###############################################################################
+# Naming conventions
+###############################################################################
+
+# --- Symbols -----------------------------------------------------------------
+dotnet_naming_symbols.public_members.applicable_kinds = property, method, event, delegate
+dotnet_naming_symbols.public_members.applicable_accessibilities = public, internal, protected, protected_internal
+
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private, private_protected
+
+dotnet_naming_symbols.private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields.applicable_accessibilities = private, private_protected
+dotnet_naming_symbols.private_static_fields.required_modifiers = static
+
+dotnet_naming_symbols.constants.applicable_kinds = field
+dotnet_naming_symbols.constants.applicable_accessibilities = *
+dotnet_naming_symbols.constants.required_modifiers = const
+
+dotnet_naming_symbols.interfaces.applicable_kinds = interface
+dotnet_naming_symbols.interfaces.applicable_accessibilities = *
+
+dotnet_naming_symbols.type_parameters.applicable_kinds = type_parameter
+dotnet_naming_symbols.type_parameters.applicable_accessibilities = *
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, enum
+dotnet_naming_symbols.types.applicable_accessibilities = *
+
+dotnet_naming_symbols.local_variables.applicable_kinds = local, parameter
+dotnet_naming_symbols.local_variables.applicable_accessibilities = *
+
+# --- Styles ------------------------------------------------------------------
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.underscore_camel_case.capitalization = camel_case
+dotnet_naming_style.underscore_camel_case.required_prefix = _
+
+dotnet_naming_style.i_prefix_pascal_case.capitalization = pascal_case
+dotnet_naming_style.i_prefix_pascal_case.required_prefix = I
+
+dotnet_naming_style.t_prefix_pascal_case.capitalization = pascal_case
+dotnet_naming_style.t_prefix_pascal_case.required_prefix = T
+
+dotnet_naming_style.camel_case.capitalization = camel_case
+
+# --- Rules (order = priority; lower number = higher priority) ----------------
+dotnet_naming_rule.constants_must_be_pascal_case.symbols = constants
+dotnet_naming_rule.constants_must_be_pascal_case.style = pascal_case
+dotnet_naming_rule.constants_must_be_pascal_case.severity = warning
+
+dotnet_naming_rule.interfaces_must_begin_with_i.symbols = interfaces
+dotnet_naming_rule.interfaces_must_begin_with_i.style = i_prefix_pascal_case
+dotnet_naming_rule.interfaces_must_begin_with_i.severity = warning
+
+dotnet_naming_rule.type_parameters_must_begin_with_t.symbols = type_parameters
+dotnet_naming_rule.type_parameters_must_begin_with_t.style = t_prefix_pascal_case
+dotnet_naming_rule.type_parameters_must_begin_with_t.severity = warning
+
+dotnet_naming_rule.private_static_fields_underscore_camel.symbols = private_static_fields
+dotnet_naming_rule.private_static_fields_underscore_camel.style = underscore_camel_case
+dotnet_naming_rule.private_static_fields_underscore_camel.severity = warning
+
+dotnet_naming_rule.private_fields_must_be_underscore_camel.symbols = private_fields
+dotnet_naming_rule.private_fields_must_be_underscore_camel.style = underscore_camel_case
+dotnet_naming_rule.private_fields_must_be_underscore_camel.severity = warning
+
+dotnet_naming_rule.public_members_must_be_pascal_case.symbols = public_members
+dotnet_naming_rule.public_members_must_be_pascal_case.style = pascal_case
+dotnet_naming_rule.public_members_must_be_pascal_case.severity = warning
+
+dotnet_naming_rule.types_must_be_pascal_case.symbols = types
+dotnet_naming_rule.types_must_be_pascal_case.style = pascal_case
+dotnet_naming_rule.types_must_be_pascal_case.severity = warning
+
+dotnet_naming_rule.locals_must_be_camel_case.symbols = local_variables
+dotnet_naming_rule.locals_must_be_camel_case.style = camel_case
+dotnet_naming_rule.locals_must_be_camel_case.severity = suggestion
+
+###############################################################################
+# XML project / config files
+###############################################################################
+[*.{config,csproj,resx,props,targets,ruleset,settings}]
+indent_size = 2
+
+###############################################################################
+# JSON files
+###############################################################################
+[*.json]
+indent_size = 2
+
+###############################################################################
+# Markdown files
+###############################################################################
+[*.md]
+trim_trailing_whitespace = false
+
+###############################################################################
+# Solution files
+###############################################################################
+[*.sln]
+indent_style = tab
+
+###############################################################################
+# Designer / generated files (relaxed rules)
+###############################################################################
+[*.Designer.cs]
+dotnet_naming_rule.private_fields_must_be_underscore_camel.severity = none
+dotnet_naming_rule.public_members_must_be_pascal_case.severity = none

--- a/.github/agents/scaffolder.agent.md
+++ b/.github/agents/scaffolder.agent.md
@@ -1,0 +1,79 @@
+---
+name: scaffolder
+description: "Scaffolds new .NET classes, interfaces, proxies, and configuration entries for the VSDCRequestSubmitter project following its established patterns."
+tools:
+  - read
+  - edit
+  - search
+  - shell
+---
+
+Scaffolds new .NET classes, interfaces, proxies, and configuration entries for the VSDCRequestSubmitter project, following its established patterns and conventions.
+
+## Instructions
+
+### Project structure
+
+- New model classes go in `VSDCRequestSubmitter/Models/`.
+- New proxy classes go in `VSDCRequestSubmitter/Proxies/`.
+- New WinForms forms go in `VSDCRequestSubmitter/` alongside `VSDCRequestSubmitter.cs`.
+
+### Namespace convention
+
+Match the folder path:
+
+- `VSDCRequestSubmitter` — root namespace for forms and top-level classes.
+- `VSDCRequestSubmitter.Models` — all model classes.
+- `VSDCRequestSubmitter.Proxies` — all proxy/HTTP client classes.
+
+### Model scaffolding
+
+- Create POCO classes with auto-properties.
+- Use `List<T>` for collections, initialized at declaration: `public List<Item> Items { get; set; } = new List<Item>();`
+- Where decimal precision matters, use a backing field with rounding in the setter (4 decimal places), matching the `Payment.Amount` pattern:
+
+```csharp
+private decimal _amount;
+public decimal Amount
+{
+    get { return _amount; }
+    set { _amount = Math.Round(value, 4); }
+}
+```
+
+### Proxy scaffolding
+
+- Use `HttpClient` with `WebRequestHandler` for certificate-based authentication.
+- Set `Content-Type: application/json` on requests.
+- Include these headers per the existing pattern in `VSDCApiProxy.cs`:
+  - `PAC` — point-of-sale activation code.
+  - `Accept-Language` — locale header.
+  - `RequestId` — unique request identifier.
+- Read base URLs and certificate paths from `Settings.Default`.
+
+### Configuration
+
+- Add new application-scoped settings to `App.config` under the `VSDCRequestSubmitter.Properties.Settings` section.
+- Update `Properties/Settings.settings` and `Properties/Settings.Designer.cs` to match.
+- Access settings via `Properties.Settings.Default.SettingName`.
+
+### NuGet packages
+
+- Add entries to `packages.config` using `targetFramework="net461"`.
+- Add corresponding `<Reference>` elements in `VSDCRequestSubmitter.csproj` pointing to the `packages/` folder with the correct `HintPath`.
+
+### JSON serialization
+
+- Use `Newtonsoft.Json` (v12.0.1) for all JSON work.
+- Always serialize with `Formatting.Indented`.
+
+### Naming conventions
+
+- **PascalCase** for classes, properties, and methods.
+- **_camelCase** for private fields (leading underscore).
+- **WinForms controls**: prefix with `txt` (TextBox), `btn` (Button), `lbl` (Label), `comboBox` (ComboBox).
+
+### After scaffolding
+
+- Remind the user to add any new `.cs` files to `VSDCRequestSubmitter.csproj` under the appropriate `<Compile Include="...">` item group if they were not auto-included.
+- Verify the build succeeds: `msbuild VSDCRequestSubmitterV3.0.sln /t:Restore;Build /p:Configuration=Debug`

--- a/.github/agents/security-reviewer.agent.md
+++ b/.github/agents/security-reviewer.agent.md
@@ -1,0 +1,73 @@
+---
+name: security-reviewer
+description: "Reviews code for security issues in this .NET Framework 4.6.1 WinForms VSDC integration app. Covers certificate handling, secrets management, HTTP/TLS security, input validation, and OWASP .NET recommendations."
+tools:
+  - read
+  - search
+  - shell
+---
+
+You are a security reviewer specialized in this .NET Framework 4.6.1 WinForms application that submits invoices to Serbia's Tax Authority VSDC system via HTTPS with X.509 client certificate authentication. Review code for security issues specific to this project's tech stack and integration patterns.
+
+When reviewing code, evaluate every finding against the following security domains.
+
+## Certificate Handling
+
+- Verify that `X509Store` is opened and closed properly using a `using` block or explicit `Dispose()`. Leaving the store open leaks unmanaged handles.
+- Check that certificate lookups by Subject CN handle the case where `X509Certificate2Collection` is empty or the certificate is not found. A missing cert must not produce a `NullReferenceException` — it should fail with a clear error message.
+- Flag any `ServerCertificateValidationCallback` that returns `true` unconditionally or ignores `SslPolicyErrors`. This disables TLS certificate verification entirely.
+- Ensure certificates are never loaded from file paths with hardcoded passwords (e.g., `new X509Certificate2("cert.pfx", "password")`). Passwords for PFX files must come from secure configuration.
+- Verify the cert store location is `StoreLocation.CurrentUser` (not `LocalMachine`) unless the app runs as a service, since `LocalMachine` requires elevated privileges and exposes certs to all users on the machine.
+
+## Secrets & Configuration
+
+- Flag any hardcoded credentials, API keys, PAC codes, VSDC URLs, or certificate subject names in `.cs` source files. All of these must be externalized to `App.config` or environment variables.
+- Verify `App.config` is listed in `.gitignore` if it contains real PAC codes, certificate names, or production VSDC endpoint URLs.
+- Flag connection strings or sensitive URIs embedded as string literals in source code.
+- Check `*.Designer.cs` generated code and `.resx` resource files for accidentally stored secrets, endpoints, or PAC values.
+- Ensure `ConfigurationManager.AppSettings` is the retrieval mechanism for sensitive settings, not hardcoded fallback values.
+
+## HTTP/TLS Security
+
+- Verify that TLS 1.2 or higher is explicitly enforced before any HTTP call:
+  ```csharp
+  ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+  ```
+  Flag if `SecurityProtocolType.Ssl3`, `Tls`, or `Tls11` are included, as they are deprecated and vulnerable.
+- Check whether certificate pinning is implemented for the VSDC API endpoint. If not, note this as a recommendation.
+- Flag any disabled certificate validation (see Certificate Handling above).
+- Verify that `Content-Type: application/json` and `Accept: application/json` headers are set on every request to `/api/v3/invoices`.
+- Check that custom headers (`PAC`, `RequestId`, `Accept-Language`) are not written to log files, `Debug.WriteLine`, `Console.WriteLine`, or `MessageBox` — the PAC header is sensitive.
+- Verify `HttpClient` and `WebRequestHandler` disposal: either wrap in `using` blocks or use a single long-lived instance. Creating and disposing `HttpClient` per-request causes socket exhaustion.
+
+## Input Validation
+
+- Flag any use of `TypeNameHandling` other than `TypeNameHandling.None` in Newtonsoft.Json `JsonSerializerSettings`. `TypeNameHandling.Auto`, `.Objects`, `.All`, or `.Arrays` enables remote code execution via deserialized type payloads.
+- Check that the user-edited JSON text from the WinForms textbox is validated (parsed with `JToken.Parse` or `JsonConvert.DeserializeObject` inside a try/catch) before being sent in the HTTP request body.
+- Verify that decimal and numeric values in the invoice are range-checked and not just precision-rounded. Out-of-range values could cause tax calculation errors or API rejections.
+- If any database access is added in the future, check for parameterized queries — flag any string concatenation in SQL statements.
+- Validate that `VSDCTargetAddress` from `App.config` is a well-formed HTTPS URL before using it in `HttpClient`. A malformed or non-HTTPS URL must be rejected.
+
+## OWASP .NET Recommendations
+
+- Check that exception handling does not expose sensitive data (stack traces, certificate details, PAC codes, internal URLs) in `MessageBox.Show()` or any UI-visible error messages. Exceptions should be logged internally and the user shown a generic message.
+- Verify that the file write to `{ExePath}\Result\Response.Json` uses `Path.Combine` with sanitized components. Flag any path construction that could allow directory traversal (e.g., if any part of the filename comes from user input or the API response).
+- Flag use of obsolete or insecure cryptographic APIs: `MD5`, `SHA1`, `DES`, `RC2`, `SSLv3`, `TripleDES`. If hashing is needed, use `SHA256` or higher.
+- Check for information disclosure in `MessageBox` messages — response bodies, full URLs with query strings, or header values should not be displayed to the user in production builds.
+- Verify the assembly is not marked `[assembly: ComVisible(true)]` in `AssemblyInfo.cs` unless COM interop is explicitly required. COM visibility exposes the assembly to external automation.
+- Verify all `IDisposable` resources are properly disposed: `HttpClient`, `WebRequestHandler`, `HttpResponseMessage`, `X509Store`, `Stream` objects, and `StreamReader`/`StreamWriter` instances. Each should be in a `using` block or disposed in a `finally` clause.
+
+## Output Format
+
+Categorize every finding by severity:
+
+- **CRITICAL**: Exploitable vulnerabilities — disabled TLS validation, `TypeNameHandling` RCE, hardcoded production credentials, exposed secrets in source control.
+- **HIGH**: Significant security weaknesses — missing TLS 1.2 enforcement, unvalidated user input sent to API, secrets in plain text config committed to repo, certificate store not closed.
+- **MEDIUM**: Defense-in-depth gaps — missing certificate pinning, no input validation on JSON textbox, information disclosure in error messages, HttpClient per-request disposal.
+- **LOW**: Best-practice recommendations — COM visibility flag, missing `.gitignore` entry for config, inconsistent `IDisposable` patterns.
+
+For each finding, include:
+
+1. The file path and line number (or line range).
+2. A description of the issue and why it matters in this VSDC integration context.
+3. A concrete code fix or remediation step.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,60 @@
+# Copilot Instructions
+
+## Project Overview
+
+VSDCRequestSubmitter is a .NET Framework 4.6.1 WinForms desktop application that helps POS developers test invoice signing against Serbia's Tax Authority VSDC system. It POSTs JSON invoice requests to the VSDC API using client certificate authentication.
+
+## Build
+
+```shell
+# Restore NuGet packages and build
+msbuild VSDCRequestSubmitterV3.0.sln /t:Restore;Build /p:Configuration=Debug
+
+# Release build
+msbuild VSDCRequestSubmitterV3.0.sln /p:Configuration=Release
+```
+
+There are no tests in this project.
+
+## Formatting & Hooks
+
+```shell
+# First-time setup after cloning
+dotnet tool restore
+dotnet husky install
+
+# Manual format check
+dotnet format VSDCRequestSubmitterV3.0.sln --no-restore --verify-no-changes
+
+# Manual format fix
+dotnet format VSDCRequestSubmitterV3.0.sln --no-restore
+```
+
+Pre-commit hooks automatically run `dotnet format` on staged `.cs` files and scan for hardcoded secrets. Pre-push hooks verify the build passes. Code style rules are in `.editorconfig`.
+
+## Architecture
+
+The app is a single-form WinForms application with three layers:
+
+- **UI** (`VSDCRequestSubmitter.cs` + `.Designer.cs`) — Main form where users edit a JSON invoice request and submit it. Settings (VSDC URL, certificate name, PAC) are loaded from `App.config` on startup.
+- **Proxies** (`Proxies/VSDCApiProxy.cs`) — HTTP client that authenticates via X.509 client certificate (loaded from the current user's certificate store by Subject CN) and POSTs to `/api/v3/invoices`. Custom headers include `PAC`, `Accept-Language`, and optional `RequestId`.
+- **Models** (`Models/InvoiceRequest.cs`) — POCO classes (`InvoiceRequest`, `Item`, `Payment`) and enums (`InvoiceType`, `TransactionType`, `PaymentType`) representing the VSDC invoice schema.
+
+The response is written to `{ExePath}\Result\Response.Json`.
+
+## Key Conventions
+
+- **NuGet package management**: Uses `packages.config` (not PackageReference). Dependencies include `Newtonsoft.Json` 12.0.1 for JSON serialization.
+- **JSON formatting**: All JSON output uses `Newtonsoft.Json` with `Formatting.Indented`.
+- **Decimal precision**: `Payment.Amount` auto-rounds to 4 decimal places via the setter.
+- **Configuration**: Three application-scoped settings in `App.config` — `VSDCTargetAddress`, `CertificateName`, `PAC`. Accessed through the generated `Settings.Designer.cs` class.
+- **WinForms controls**: Prefixed by type (`txt`, `btn`, `lbl`, `comboBox`). UI layout uses anchor styles for responsive resizing.
+- **Namespaces**: Root `VSDCRequestSubmitter`, with `.Models` and `.Proxies` sub-namespaces matching folder structure.
+- **No hardcoded secrets**: All sensitive values (URL, certificate CN, PAC) are externalized to `App.config`.
+
+## MCP Servers
+
+Two MCP servers are configured in `.vscode/mcp.json`:
+
+- **Context7** — Fetches live, version-specific documentation for libraries (Newtonsoft.Json, System.Net.Http, etc.). Add `use context7` to your prompt for up-to-date API references.
+- **GitHub** — Access PRs, issues, and code search directly from Copilot Chat. Requires a GitHub PAT (prompted on first use).

--- a/.github/hooks/hooks.json
+++ b/.github/hooks/hooks.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "./scripts/copilot-pre-tool-check.sh",
+        "powershell": ".\\scripts\\copilot-pre-tool-check.ps1",
+        "cwd": ".",
+        "timeoutSec": 15
+      }
+    ],
+    "postToolUse": [
+      {
+        "type": "command",
+        "bash": "echo '{\"decision\":\"allow\"}'",
+        "powershell": "Write-Output '{\"decision\":\"allow\"}'",
+        "cwd": ".",
+        "timeoutSec": 5
+      }
+    ]
+  }
+}

--- a/.github/skills/certificate-ops/SKILL.md
+++ b/.github/skills/certificate-ops/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: certificate-ops
+description: "Use when working with X.509 certificates, PFX files, or certificate store operations in this VSDC integration project."
+---
+
+# Certificate Operations
+
+This application uses X.509 client certificate authentication to communicate with the VSDC Tax Authority API.
+
+## Certificate Store Pattern
+
+Load a certificate by Subject CN from the current user's personal store:
+
+```csharp
+private static X509Certificate2 LoadMyCertificate(string cn)
+{
+    using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+    {
+        store.Open(OpenFlags.ReadOnly);
+        var certs = store.Certificates.Find(
+            X509FindType.FindBySubjectName, cn, validOnly: false);
+
+        if (certs.Count == 0)
+            throw new InvalidOperationException(
+                $"Certificate with Subject CN '{cn}' not found in CurrentUser\\My store.");
+
+        return certs[0];
+    }
+}
+```
+
+Key points:
+- Always use `using` or `Dispose()` on `X509Store`
+- Store location: `CurrentUser` (not `LocalMachine` — avoids needing admin privileges)
+- Store name: `My` (personal certificate store)
+- The `cn` value comes from App.config setting `CertificateName`
+
+## Attaching Certificate to HttpClient
+
+```csharp
+var handler = new WebRequestHandler();
+handler.ClientCertificateOptions = ClientCertificateOptions.Manual;
+handler.ClientCertificates.Add(LoadMyCertificate(cn));
+
+using (var client = new HttpClient(handler))
+{
+    // make request
+}
+```
+
+## Certificate Prerequisites
+
+Before the app can authenticate:
+1. ROOT certificate from Tax Authority → install to machine `Trusted Root Certification Authorities` store
+2. Issuing (intermediate) certificate → install to machine `Intermediate Certification Authorities` store
+3. POS PFX file → import to `CurrentUser\My` (Personal) store using the password provided by Tax Authority
+
+## Validation Checklist
+
+When reviewing or writing certificate code:
+- [ ] `X509Store` is disposed (using block)
+- [ ] Empty certificate collection is handled (not null, but `.Count == 0`)
+- [ ] `ServerCertificateValidationCallback` does NOT blindly return `true`
+- [ ] No PFX passwords hardcoded in source — use App.config or SecureString
+- [ ] Certificate is loaded once and reused per request, not per-call store lookup in a loop

--- a/.github/skills/csproj-management/SKILL.md
+++ b/.github/skills/csproj-management/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: csproj-management
+description: "Use when adding files, NuGet references, or configuration settings to the VSDCRequestSubmitter project. Covers .csproj edits, packages.config, and App.config management."
+---
+
+# Project File Management
+
+Project file: `VSDCRequestSubmitter/VSDCRequestSubmitterV3.0.csproj`
+
+## Adding Source Files
+
+This is a legacy .csproj format (not SDK-style) — files are NOT auto-included. Every new `.cs` file must be explicitly added:
+
+```xml
+<ItemGroup>
+  <Compile Include="Models\NewModel.cs" />
+</ItemGroup>
+```
+
+Place the entry in the appropriate `<ItemGroup>` near similar files. Models with Models, Proxies with Proxies.
+
+## Adding NuGet Packages
+
+Two files must be updated:
+
+### 1. packages.config
+```xml
+<package id="PackageName" version="1.0.0" targetFramework="net461" />
+```
+
+### 2. .csproj Reference
+```xml
+<Reference Include="PackageName, Version=1.0.0.0, Culture=neutral, PublicKeyToken=...">
+  <HintPath>..\packages\PackageName.1.0.0\lib\net461\PackageName.dll</HintPath>
+</Reference>
+```
+
+After adding, run `nuget restore` then `msbuild /t:Build` to verify.
+
+## App.config Settings
+
+Application-scoped settings go in the `<applicationSettings>` section:
+
+```xml
+<applicationSettings>
+  <VSDCRequestSubmitter.Properties.Settings>
+    <setting name="NewSettingName" serializeAs="String">
+      <value>DEFAULT_VALUE</value>
+    </setting>
+  </VSDCRequestSubmitter.Properties.Settings>
+</applicationSettings>
+```
+
+Also update these two files to match:
+- `Properties/Settings.settings` — add the setting definition
+- `Properties/Settings.Designer.cs` — add the generated property accessor
+
+Access pattern in code:
+```csharp
+var value = Properties.Settings.Default.NewSettingName;
+```
+
+## Adding Forms
+
+WinForms require three files — all must be added to .csproj:
+
+```xml
+<Compile Include="NewForm.cs">
+  <SubType>Form</SubType>
+</Compile>
+<Compile Include="NewForm.Designer.cs">
+  <DependentUpon>NewForm.cs</DependentUpon>
+</Compile>
+<EmbeddedResource Include="NewForm.resx">
+  <DependentUpon>NewForm.cs</DependentUpon>
+</EmbeddedResource>
+```

--- a/.github/skills/dotnet-build/SKILL.md
+++ b/.github/skills/dotnet-build/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: dotnet-build
+description: "Use when building, restoring, or troubleshooting the .NET Framework 4.6.1 solution. Covers MSBuild commands, NuGet restore via packages.config, and binding redirect issues."
+---
+
+# .NET Framework Build
+
+## Solution
+
+Single solution: `VSDCRequestSubmitterV3.0.sln` with one project in `VSDCRequestSubmitter/`.
+
+Target framework: .NET Framework 4.6.1 (`net461`).
+
+## Build Commands
+
+Restore and build:
+```shell
+msbuild VSDCRequestSubmitterV3.0.sln /t:Restore;Build /p:Configuration=Debug
+```
+
+Release build:
+```shell
+msbuild VSDCRequestSubmitterV3.0.sln /p:Configuration=Release
+```
+
+Clean:
+```shell
+msbuild VSDCRequestSubmitterV3.0.sln /t:Clean
+```
+
+## NuGet Restore
+
+This project uses `packages.config` (not PackageReference). NuGet packages are restored to a `packages/` folder at the solution root.
+
+If restore fails, try:
+```shell
+nuget restore VSDCRequestSubmitterV3.0.sln
+```
+
+## Binding Redirects
+
+`App.config` contains assembly binding redirects for:
+- `System.Net.Http` → 4.1.1.3
+- `Newtonsoft.Json` → 12.0.0.0
+
+If adding or upgrading a NuGet package causes runtime `FileLoadException` or `MissingMethodException`, check whether a new binding redirect is needed in `App.config` under `<runtime><assemblyBinding>`.
+
+## Common Issues
+
+- **Missing MSBuild**: Ensure Visual Studio Build Tools or Visual Studio with .NET desktop workload is installed. MSBuild is at `C:\Program Files\Microsoft Visual Studio\2022\...\MSBuild\Current\Bin\MSBuild.exe`.
+- **packages/ not found**: Run `nuget restore` before `msbuild`. The `packages.config` file lists all dependencies.
+- **Target framework not installed**: .NET Framework 4.6.1 Developer Pack must be installed.

--- a/.github/skills/vsdc-api/SKILL.md
+++ b/.github/skills/vsdc-api/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: vsdc-api
+description: "Use when working with the VSDC Tax Authority API — invoice submission endpoint, request/response format, required headers, and error handling."
+---
+
+# VSDC API v3 Integration
+
+## Endpoint
+
+```
+POST {VSDCTargetAddress}/api/v3/invoices
+```
+
+Base URL is configured in App.config as `VSDCTargetAddress`.
+
+## Required Headers
+
+| Header | Source | Notes |
+|--------|--------|-------|
+| `Content-Type` | Hardcoded | `application/json` |
+| `PAC` | App.config | Payment Authorization Code from Tax Authority |
+| `Accept-Language` | User selection | `en-US`, `sr-Cyrl-RS`, or omit for default |
+| `RequestId` | User input | Optional unique request identifier |
+
+## Invoice Request Schema
+
+```json
+{
+  "DateAndTimeOfIssue": "2024-01-01T12:00:00",
+  "Cashier": "string (optional)",
+  "BuyerId": "string (optional)",
+  "BuyerCostCenterId": "string (optional)",
+  "InvoiceType": 0,
+  "TransactionType": 0,
+  "Payment": [
+    {
+      "Amount": 1000.0000,
+      "PaymentType": 0
+    }
+  ],
+  "InvoiceNumber": "string (optional)",
+  "ReferentDocumentNumber": "string (optional)",
+  "ReferentDocumentDT": "datetime (optional)",
+  "Items": [
+    {
+      "GTIN": "string (barcode, optional)",
+      "Name": "string",
+      "Quantity": 1.0,
+      "Discount": 0.0,
+      "Labels": ["A"],
+      "UnitPrice": 100.87,
+      "TotalAmount": 100.87
+    }
+  ]
+}
+```
+
+## Enums
+
+**InvoiceType**: Normal (0), ProForma (1), Copy (2), Training (3), Advance (4)
+
+**TransactionType**: Sale (0), Refund (1)
+
+**PaymentType**: Other (0), Cash (1), Card (2), Check (3), WireTransfer (4), Voucher (5), MobileMoney (6)
+
+## Decimal Precision
+
+`Payment.Amount` is rounded to 4 decimal places automatically. Apply the same precision to any new monetary fields.
+
+## Response Handling
+
+The API response (JSON) is written to:
+```
+{Application.ExecutablePath}\Result\Response.Json
+```
+
+The `Result` directory is created if it doesn't exist before writing.
+
+## Error Handling Pattern
+
+```csharp
+try
+{
+    var response = await client.PostAsJsonAsync(
+        VSDCAddress + "/api/v3/invoices", request);
+    var result = await response.Content.ReadAsStringAsync();
+    // write result to file
+}
+catch (HttpRequestException ex)
+{
+    // Network or TLS error — check certificate and URL
+}
+catch (TaskCanceledException ex)
+{
+    // Timeout — VSDC server may be unreachable
+}
+```
+
+## Language Support
+
+Three options for `Accept-Language`:
+- `default` — omit header entirely (server default)
+- `en-US` — English
+- `sr-Cyrl-RS` — Serbian Cyrillic

--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -1,0 +1,26 @@
+{
+  "tasks": [
+    {
+      "name": "dotnet-format-staged",
+      "group": "pre-commit",
+      "command": "dotnet",
+      "args": ["format", "VSDCRequestSubmitterV3.0.sln", "--no-restore", "--include", "${staged}"],
+      "include": ["**/*.cs"],
+      "exclude": ["**/*.Designer.cs"]
+    },
+    {
+      "name": "check-secrets",
+      "group": "pre-commit",
+      "command": "bash",
+      "args": ["scripts/check-secrets.sh"],
+      "include": ["**/*.cs"]
+    },
+    {
+      "name": "build-verify",
+      "group": "pre-push",
+      "command": "dotnet",
+      "args": ["msbuild", "VSDCRequestSubmitterV3.0.sln", "/t:Build", "/p:Configuration=Debug", "/v:minimal", "/nologo"],
+      "output": "verbose"
+    }
+  ]
+}

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,25 @@
+{
+  "servers": {
+    "Context7": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp@latest"]
+    },
+    "GitHub": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${input:github_pat}"
+      }
+    }
+  },
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "github_pat",
+      "description": "GitHub Personal Access Token (for MCP server)",
+      "password": true
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.preferCSharpExtension": true
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,104 @@
+# AGENTS.md
+
+Instructions for AI coding agents (Codex, Jules, OpenCode) working in this repository.
+See `.github/copilot-instructions.md` for additional project-specific guidance.
+
+## Project overview
+
+VSDCRequestSubmitter is a .NET Framework 4.6.1 WinForms desktop application for testing invoice signing against Serbia's Tax Authority VSDC system. It POSTs JSON invoice requests to the VSDC API (`/api/v3/invoices`) using X.509 client certificate authentication.
+
+## Build
+
+```
+msbuild VSDCRequestSubmitterV3.0.sln /t:Restore;Build /p:Configuration=Debug
+```
+
+No test suite exists. Code formatting is enforced via pre-commit hooks:
+
+```
+dotnet tool restore && dotnet husky install
+```
+
+Pre-commit hooks (Husky.NET) run `dotnet format` on staged `.cs` files and scan for hardcoded secrets. Pre-push hooks verify the build.
+
+## Architecture
+
+The solution contains a single project (`VSDCRequestSubmitter/`) with three layers:
+
+| Layer | File(s) | Responsibility |
+|-------|---------|----------------|
+| **UI** | `VSDCRequestSubmitter.cs` + `.Designer.cs` | WinForms main form — user input, request composition, response display |
+| **Proxies** | `Proxies/VSDCApiProxy.cs` | HTTP client — loads X.509 cert, attaches custom headers (PAC, Accept-Language, RequestId), POSTs JSON to VSDC API |
+| **Models** | `Models/InvoiceRequest.cs` | POCO classes: `InvoiceRequest`, `Item`, `Payment` + enums (`InvoiceType`, `TransactionType`, `PaymentType`) |
+
+## Conventions
+
+- **Namespaces:** `VSDCRequestSubmitter`, `VSDCRequestSubmitter.Models`, `VSDCRequestSubmitter.Proxies`
+- **Naming:** PascalCase for public members, `_camelCase` for private fields
+- **WinForms controls:** Prefixed — `txt`, `btn`, `lbl`, `comboBox`
+- **JSON serialization:** Newtonsoft.Json with `Formatting.Indented`
+- **Payment.Amount:** Auto-rounds to 4 decimal places
+- **Configuration:** Application-scoped settings in `App.config` (`VSDCTargetAddress`, `CertificateName`, `PAC`), accessed via `Settings.Designer.cs`
+- **NuGet:** Uses `packages.config` (not PackageReference) — Newtonsoft.Json 12.0.1, System.Net.Http, cryptography libs
+- **Binding redirects:** Present in `App.config` for `System.Net.Http` and `Newtonsoft.Json`
+
+## Security
+
+- **Certificate auth:** X.509 client certificate loaded from `CurrentUser\My` store by Subject CN (configured in `App.config` as `CertificateName`)
+- **No hardcoded secrets:** All sensitive values (PAC, certificate name, target address) are externalized to `App.config`
+- **Custom headers:** Each request includes `PAC`, `Accept-Language`, and a unique `RequestId`
+
+## Hooks
+
+### Git hooks (Husky.NET)
+
+Pre-commit and pre-push hooks are managed by Husky.NET. After cloning:
+
+```
+dotnet tool restore
+dotnet husky install
+```
+
+| Hook | Task | What it does |
+|------|------|-------------|
+| pre-commit | `dotnet-format-staged` | Formats staged `.cs` files (excludes `*.Designer.cs`) |
+| pre-commit | `check-secrets` | Scans for hardcoded PAC codes, URLs, cert passwords |
+| pre-push | `build-verify` | MSBuild debug build verification |
+
+Skip hooks in emergencies: `git commit --no-verify`
+
+Configuration: `.husky/task-runner.json`, `.config/dotnet-tools.json`
+
+### Copilot agent hooks
+
+Pre-tool-use hooks in `.github/hooks/hooks.json` protect critical files from accidental agent operations:
+- Blocks deletion of `.sln`, `.csproj`, `App.config`, `packages.config`
+- Blocks destructive `rm -rf` on project root or `.git`
+- Blocks modifications to `.github/hooks/` (self-protection)
+
+## Custom agents
+
+Copilot custom agents are available in `.github/agents/`:
+
+- **`scaffolder`** — .NET scaffolding (new models, forms, proxy methods). Tools: read, edit, search, shell.
+- **`security-reviewer`** — Security analysis (certificate handling, secret management, HTTP configuration). Tools: read, search, shell.
+
+## Skills
+
+Modular skills in `.github/skills/` are loaded on-demand when relevant:
+
+| Skill | When to use |
+|-------|------------|
+| **`dotnet-build`** | Building, restoring, or troubleshooting MSBuild and NuGet issues |
+| **`csproj-management`** | Adding files, NuGet references, App.config settings, or WinForms to the project |
+| **`certificate-ops`** | X.509 certificate store operations, PFX handling, cert validation |
+| **`vsdc-api`** | VSDC Tax Authority API endpoint format, headers, JSON schema, error handling |
+
+## MCP servers
+
+Two MCP servers are configured in `.vscode/mcp.json` (requires Node.js 18+):
+
+| Server | Package | Purpose |
+|--------|---------|---------|
+| **Context7** | `@upstash/context7-mcp` | Live, version-specific library documentation. Add `use context7` to prompts for current API references. |
+| **GitHub** | `@modelcontextprotocol/server-github` | PR management, issue tracking, code search. Requires GitHub PAT (prompted on first use). |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,139 @@
+# Contributing to VSDC Request Submitter V3.0
+
+## Development Setup
+
+```bash
+git clone git@github.com:Data-Tech-International/VSDCRequestSubmitterV3.0.git
+cd VSDCRequestSubmitterV3.0
+dotnet tool restore
+dotnet husky install
+msbuild VSDCRequestSubmitterV3.0.sln /t:Restore;Build /p:Configuration=Debug
+```
+
+**Prerequisites**: Visual Studio 2017+ with .NET Framework 4.6.1 targeting pack, MSBuild on PATH.
+
+## Code Style
+
+Code style is enforced by `.editorconfig` and `dotnet format`. Key rules:
+
+| Rule | Convention |
+|---|---|
+| Indentation | 4 spaces |
+| Classes, properties, methods | `PascalCase` |
+| Private fields | `_camelCase` (leading underscore) |
+| Brace style | Allman (braces on new lines) |
+| Namespaces | Block-scoped (`namespace X { }`, not file-scoped) |
+| WinForms controls | `txt` (TextBox), `btn` (Button), `lbl` (Label), `comboBox` (ComboBox) |
+
+**Check formatting** (CI-safe, no modifications):
+
+```bash
+dotnet format VSDCRequestSubmitterV3.0.sln --no-restore --verify-no-changes
+```
+
+**Fix formatting**:
+
+```bash
+dotnet format VSDCRequestSubmitterV3.0.sln --no-restore
+```
+
+## Pre-commit Hooks
+
+Managed by [Husky.NET](https://alirezanet.github.io/Husky.Net/). Hooks run automatically — no manual setup beyond `dotnet husky install`.
+
+**Pre-commit** (every commit):
+
+- `dotnet format` on staged `.cs` files (excludes `*.Designer.cs`)
+- Secrets scanner — blocks commits containing hardcoded PAC codes, VSDC URLs, or certificate passwords
+
+**Pre-push**:
+
+- Full MSBuild build verification
+
+**Skip in emergencies**:
+
+```bash
+git commit --no-verify
+```
+
+Configuration lives in `.husky/task-runner.json`.
+
+## Project Structure
+
+```
+VSDCRequestSubmitter/
+├── Models/InvoiceRequest.cs           # POCO models + enums
+├── Proxies/VSDCApiProxy.cs            # HTTP client with X.509 cert auth
+├── VSDCRequestSubmitter.cs            # Main WinForms form logic
+├── VSDCRequestSubmitter.Designer.cs   # Auto-generated UI (DO NOT edit manually)
+├── Properties/                        # Assembly info, settings
+├── App.config                         # Runtime configuration
+└── packages.config                    # NuGet dependencies
+```
+
+## Adding New Code
+
+### New models
+
+Add to `VSDCRequestSubmitter/Models/`, namespace `VSDCRequestSubmitter.Models`.
+
+### New proxies
+
+Add to `VSDCRequestSubmitter/Proxies/`, namespace `VSDCRequestSubmitter.Proxies`.
+
+### New forms
+
+Add to the project root, namespace `VSDCRequestSubmitter`.
+
+### Legacy .csproj requirement
+
+This project uses a legacy (non-SDK-style) `.csproj`. New `.cs` files are **not** automatically included — you must manually add them to `VSDCRequestSubmitterV3.0.csproj`:
+
+```xml
+<Compile Include="Models\YourNewModel.cs" />
+```
+
+### NuGet packages
+
+Update **both** `packages.config` **and** the `.csproj` `HintPath` references when adding or upgrading packages.
+
+## Security Guidelines
+
+- **NEVER** hardcode PAC codes, certificate names, VSDC URLs, or passwords in source code.
+- All sensitive values belong in `App.config`.
+- The pre-commit secrets scanner will block commits containing hardcoded secrets.
+- Use `SecureString` for certificate passwords where possible.
+
+## Branching & Pull Requests
+
+1. Create feature branches from `main`: `feature/description` or `fix/description`.
+2. Keep PRs focused — one feature or fix per PR.
+3. Ensure the build passes before submitting (the pre-push hook verifies this).
+4. Reference related issues in the PR description (e.g., `Closes #2`).
+
+## AI-Assisted Development
+
+This repository includes Copilot configuration for AI-assisted development.
+
+### Custom Agents (`.github/agents/`)
+
+| Agent | Purpose |
+|---|---|
+| `@scaffolder` | Generates new .NET classes, proxies, and configuration following project patterns |
+| `@security-reviewer` | Reviews code for security issues (certs, secrets, HTTP/TLS, OWASP) |
+
+### Skills (`.github/skills/`)
+
+| Skill | Purpose |
+|---|---|
+| `dotnet-build` | Build and NuGet troubleshooting |
+| `csproj-management` | Project file and config management |
+| `certificate-ops` | X.509 certificate operations |
+| `vsdc-api` | VSDC API integration reference |
+
+### MCP Servers (`.vscode/mcp.json`)
+
+- **Context7** — Add `use context7` to prompts for live library documentation.
+- **GitHub** — PR/issue management from Copilot Chat.
+
+See `AGENTS.md` and `.github/copilot-instructions.md` for full AI tooling details.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,44 @@
 # VSDCRequestSubmitter
-Basic VSDC invoice sign submitting app, created with intention to help POS developers to integrate with TaxCore system
 
-Use this mini app to send an invoice request in order to get signature from VSDC system.
-
-Contact Tax Authority to obtain POS PFX file along with corresponding ROOT and Issuing certificates.
+A .NET Framework 4.6.1 WinForms desktop application for testing invoice signing against Serbia's Tax Authority **VSDC** (Virtual Secure Digital Card) system. Built to help POS developers integrate with the **TaxCore** fiscalization platform by submitting JSON invoice requests to the VSDC API using X.509 client certificate authentication.
 
 ## Version and Applicability
 
-This version applies to following environments
+This version applies to the **Serbia** environment.
 
-- Serbia
+## Prerequisites
 
-## Follow these steps:
+| Requirement | Purpose |
+|-------------|---------|
+| Visual Studio 2017+ (or Build Tools) with **.NET desktop development** workload | Build & run |
+| .NET Framework 4.6.1 Developer Pack | Target framework |
+| .NET SDK 8.0+ | Tooling (`dotnet format`, Husky.NET) |
+| Node.js 18+ | MCP servers (Context7, GitHub) |
+| POS PFX certificate + ROOT and Issuing certificates | Client authentication — obtained from Tax Authority |
+| PAC (Payment Authorization Code) | Invoice submission — obtained from Tax Authority |
 
-* Install ROOT and Issuing certificates to machine certificate store based on guide provided by the Tax Authority.
-* Install POS PFX file to the current user personal store.
-* Set VSDC target address.
-* Set POS PFX file Subject CN.
-* Edit Request to suit your personal needs.
-* Do not forget to edit PAC code received along with POS PFX file and password.
-* Submit request and find results on the link provided from MessageBox.
+## Getting Started
 
-_To avoid constant setting of VSDC server address and PFX CN from app interface, you can set them by editing app.config file._
+### 1. Clone the repository
+
+```shell
+git clone <repository-url>
+cd VSDCRequestSubmitterV3.0
+```
+
+### 2. Install certificates
+
+| Certificate | Store | Scope |
+|-------------|-------|-------|
+| ROOT certificate | Trusted Root Certification Authorities | Local Machine |
+| Issuing certificate | Intermediate Certification Authorities | Local Machine |
+| POS PFX file | Personal (My) | Current User |
+
+Install certificates using the Windows Certificate Manager (`certmgr.msc` / `certlm.msc`) or follow the guide provided by the Tax Authority.
+
+### 3. Configure App.config
+
+Update the application settings with your environment values:
 
 ```xml
 <applicationSettings>
@@ -35,3 +52,149 @@ _To avoid constant setting of VSDC server address and PFX CN from app interface,
     </VSDCRequestSubmitter.Properties.Settings>
 </applicationSettings>
 ```
+
+Set the **PAC** value in the corresponding App.config setting.
+
+### 4. Set up dev tools
+
+```shell
+dotnet tool restore
+dotnet husky install
+```
+
+### 5. Build
+
+```shell
+msbuild VSDCRequestSubmitterV3.0.sln /t:Restore;Build /p:Configuration=Debug
+```
+
+### 6. Run
+
+Launch the application, verify the loaded settings, edit the JSON request body as needed, and submit a test invoice.
+
+## Build Commands
+
+```shell
+# Debug build
+msbuild VSDCRequestSubmitterV3.0.sln /t:Restore;Build /p:Configuration=Debug
+
+# Release build
+msbuild VSDCRequestSubmitterV3.0.sln /p:Configuration=Release
+
+# Clean
+msbuild VSDCRequestSubmitterV3.0.sln /t:Clean
+```
+
+## Architecture
+
+Single-form WinForms application with three layers:
+
+| Layer | Files | Responsibility |
+|-------|-------|----------------|
+| **UI** | `VSDCRequestSubmitter.cs`, `.Designer.cs` | Main form — loads settings from App.config, provides an editable JSON request body, submits to VSDC |
+| **Proxies** | `Proxies/VSDCApiProxy.cs` | HTTP client with X.509 client certificate authentication, POSTs to `/api/v3/invoices` |
+| **Models** | `Models/InvoiceRequest.cs` | POCO classes (`InvoiceRequest`, `Item`, `Payment`) and enums |
+
+## VSDC API Reference
+
+**Endpoint:** `POST {VSDCTargetAddress}/api/v3/invoices`
+
+### Headers
+
+| Header | Source | Required |
+|--------|--------|----------|
+| `Content-Type` | `application/json` | Yes |
+| `PAC` | App.config | Yes |
+| `Accept-Language` | User selection (`en-US`, `sr-Cyrl-RS`, or omit for default) | No |
+| `RequestId` | User input | No |
+
+### Request Body Example
+
+```json
+{
+  "DateAndTimeOfIssue": "2024-01-01T12:00:00",
+  "InvoiceType": 0,
+  "TransactionType": 0,
+  "Payment": [{ "Amount": 1000.0000, "PaymentType": 1 }],
+  "Items": [
+    {
+      "Name": "Network Cable",
+      "Quantity": 1.0,
+      "Labels": ["A"],
+      "UnitPrice": 100.87,
+      "TotalAmount": 100.87
+    }
+  ]
+}
+```
+
+### Enums
+
+**InvoiceType**
+
+| Name | Value |
+|------|-------|
+| Normal | 0 |
+| ProForma | 1 |
+| Copy | 2 |
+| Training | 3 |
+| Advance | 4 |
+
+**TransactionType**
+
+| Name | Value |
+|------|-------|
+| Sale | 0 |
+| Refund | 1 |
+
+**PaymentType**
+
+| Name | Value |
+|------|-------|
+| Other | 0 |
+| Cash | 1 |
+| Card | 2 |
+| Check | 3 |
+| WireTransfer | 4 |
+| Voucher | 5 |
+| MobileMoney | 6 |
+
+### Response
+
+The VSDC response is written to `{ExePath}\Result\Response.Json`.
+
+## Configuration Reference
+
+| Setting | Description | Location |
+|---------|-------------|----------|
+| `VSDCTargetAddress` | VSDC server URL | App.config |
+| `CertificateName` | POS PFX certificate Subject CN | App.config |
+| `PAC` | Payment Authorization Code | App.config |
+
+```xml
+<applicationSettings>
+    <VSDCRequestSubmitter.Properties.Settings>
+      <setting name="VSDCTargetAddress" serializeAs="String">
+        <value>REPLACE WITH VSDC URL</value>
+      </setting>
+      <setting name="CertificateName" serializeAs="String">
+        <value>REPLACE WITH POS PFX Certificate Name (Subject CN)</value>
+      </setting>
+    </VSDCRequestSubmitter.Properties.Settings>
+</applicationSettings>
+```
+
+## Security
+
+- **Client certificate authentication** — X.509 certificate loaded from the `CurrentUser\My` store.
+- **No hardcoded secrets** — all sensitive values are stored in `App.config` (excluded from source control).
+- **Pre-commit hooks** — Husky.NET hooks scan for accidentally committed secrets.
+- **TLS** — all communication with the VSDC API is encrypted in transit.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute to this project.
+
+## License
+
+See [LICENSE](LICENSE) for details.

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.100",
+    "rollForward": "latestMajor",
+    "allowPrerelease": false
+  }
+}

--- a/scripts/check-secrets.sh
+++ b/scripts/check-secrets.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# check-secrets.sh - Scan staged files for hardcoded secrets
+# Used as a pre-commit hook via Husky.NET
+# Exit 0 = clean, Exit 1 = secrets found
+
+set -euo pipefail
+
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Get staged .cs files, or use arguments if provided
+if [ $# -gt 0 ]; then
+    FILES="$@"
+else
+    FILES=$(git diff --cached --name-only --diff-filter=ACM -- '*.cs' 2>/dev/null || true)
+fi
+
+if [ -z "$FILES" ]; then
+    exit 0
+fi
+
+FOUND=0
+
+# Filter out Designer.cs files (auto-generated content)
+FILTERED_FILES=""
+for f in $FILES; do
+    if [[ "$f" == *.Designer.cs ]]; then
+        continue
+    fi
+    if [ -f "$f" ]; then
+        FILTERED_FILES="$FILTERED_FILES $f"
+    fi
+done
+
+if [ -z "$FILTERED_FILES" ]; then
+    exit 0
+fi
+
+check_pattern() {
+    local label="$1"
+    local pattern="$2"
+    shift 2
+    local files="$@"
+
+    for f in $files; do
+        # Run grep; skip lines containing known placeholder text
+        matches=$(grep -nE "$pattern" "$f" 2>/dev/null \
+            | grep -ivE "REPLACE WITH|TODO|EXAMPLE|PLACEHOLDER|CHANGEME|YOUR_.*_HERE|xxxx|sample" || true)
+
+        if [ -n "$matches" ]; then
+            while IFS= read -r line; do
+                echo -e "${RED}[SECRET DETECTED]${NC} ${YELLOW}${label}${NC}"
+                echo "  $f:$line"
+            done <<< "$matches"
+            FOUND=1
+        fi
+    done
+}
+
+echo "Scanning for hardcoded secrets..."
+
+# 1. PAC codes — literal PAC values that look like real codes
+check_pattern "Hardcoded PAC code" \
+    'PAC\s*=\s*"[A-Za-z0-9]{8,}"' \
+    $FILTERED_FILES
+
+# 2. Hardcoded VSDC/TaxCore URLs in .cs source (App.config is fine)
+check_pattern "Hardcoded VSDC/TaxCore URL" \
+    'https?://[^"]*vsdc|https?://[^"]*taxcore' \
+    $FILTERED_FILES
+
+# 3. Certificate / PFX passwords
+check_pattern "Certificate password" \
+    'new\s+X509Certificate2\s*\(.*".*",\s*"[^"]+"' \
+    $FILTERED_FILES
+
+check_pattern "Hardcoded password" \
+    'password\s*=\s*"[^"]+"' \
+    $FILTERED_FILES
+
+# 4. Connection strings in .cs files
+check_pattern "Hardcoded connection string" \
+    '(Server\s*=|Data Source\s*=|Initial Catalog\s*=)' \
+    $FILTERED_FILES
+
+# 5. Private keys
+check_pattern "Embedded private key" \
+    '-----BEGIN (RSA |EC )?PRIVATE KEY-----' \
+    $FILTERED_FILES
+
+# 6. API keys / secrets / tokens
+check_pattern "Hardcoded API key/secret/token" \
+    '(api[_-]?key|secret|token)\s*[:=]\s*"[^"]{8,}"' \
+    $FILTERED_FILES
+
+if [ "$FOUND" -eq 1 ]; then
+    echo ""
+    echo -e "${RED}Secrets detected! Commit blocked.${NC}"
+    echo "Move sensitive values to App.config, environment variables, or a secrets manager."
+    exit 1
+fi
+
+echo "No secrets found."
+exit 0

--- a/scripts/copilot-pre-tool-check.sh
+++ b/scripts/copilot-pre-tool-check.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# copilot-pre-tool-check.sh
+# Validates Copilot agent tool invocations before execution.
+# Reads JSON from stdin, outputs permission decision as JSON.
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Extract tool name and arguments using python3 (jq may not be available)
+eval "$(echo "$INPUT" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    data = {}
+tool = data.get('tool') or data.get('toolName') or 'unknown'
+args = data.get('args') or data.get('arguments') or data.get('input') or ''
+if isinstance(args, dict):
+    args = json.dumps(args)
+# Shell-escape single quotes
+tool = tool.replace(\"'\", \"'\\\"'\\\"'\")
+args = str(args).replace(\"'\", \"'\\\"'\\\"'\")
+print(f\"TOOL='{tool}'\")
+print(f\"ARGS='{args}'\")
+" 2>/dev/null || echo "TOOL='unknown'; ARGS=''")"
+
+# Protected files that agents must not delete
+PROTECTED_FILES="\.sln$|\.csproj$|App\.config$|packages\.config$|\.editorconfig$|global\.json$|\.gitignore$|\.gitattributes$"
+
+# Check for dangerous operations
+case "$TOOL" in
+  delete_file|remove|rm)
+    if echo "$ARGS" | grep -qE "$PROTECTED_FILES"; then
+      echo "{\"permissionDecision\":\"deny\",\"reason\":\"Deletion of protected project files is not allowed.\"}"
+      exit 0
+    fi
+    ;;
+  shell|bash|terminal|execute)
+    # Block rm -rf on project root or .git
+    if echo "$ARGS" | grep -qE "rm\s+-rf\s+(\.|/|\.git)"; then
+      echo "{\"permissionDecision\":\"deny\",\"reason\":\"Destructive recursive deletion is blocked.\"}"
+      exit 0
+    fi
+    # Block modifications to hooks directory
+    if echo "$ARGS" | grep -qE "(edit|write|rm|mv).*\.github/hooks/"; then
+      echo "{\"permissionDecision\":\"deny\",\"reason\":\"Modification of Copilot hooks is not allowed.\"}"
+      exit 0
+    fi
+    ;;
+  edit|write_file)
+    # Block editing hooks config
+    if echo "$ARGS" | grep -qE "\.github/hooks/"; then
+      echo "{\"permissionDecision\":\"deny\",\"reason\":\"Modification of Copilot hooks is not allowed.\"}"
+      exit 0
+    fi
+    ;;
+esac
+
+# Allow by default
+echo "{\"permissionDecision\":\"allow\"}"
+exit 0


### PR DESCRIPTION
## Summary

Comprehensive documentation overhaul and Copilot/AI tooling setup for the repository.

### Documentation
- **README.md** — Rewritten with prerequisites, setup guide, build commands, architecture, VSDC API reference (endpoint, headers, JSON schema, all enums), App.config reference, security policy
- **CONTRIBUTING.md** — New file covering code style, formatting, pre-commit hooks, project structure, branching/PR process, AI-assisted development tooling

### Copilot & AI Agent Configuration
- `.github/copilot-instructions.md` — Project-specific Copilot instructions
- `AGENTS.md` — AI coding agent instructions (Codex, Jules, OpenCode)
- Custom agents (`.github/agents/`): `scaffolder`, `security-reviewer`
- Skills (`.github/skills/`): `dotnet-build`, `csproj-management`, `certificate-ops`, `vsdc-api`
- MCP servers (`.vscode/mcp.json`): Context7 + GitHub

### Developer Tooling
- `.editorconfig` — C# code style rules matching existing conventions
- Husky.NET — Pre-commit hooks (dotnet format + secrets scan), pre-push build verification
- `global.json` — .NET SDK 8+ pinning for tooling
- Copilot hooks (`.github/hooks/hooks.json`) — Pre-tool-use safety gates
- Scripts: `check-secrets.sh`, `copilot-pre-tool-check.sh`

### Stats
- 19 files changed, ~1400 lines added

Closes #2